### PR TITLE
Fix missing null termination of output_file_path

### DIFF
--- a/decode_binary.c
+++ b/decode_binary.c
@@ -60,7 +60,7 @@ char * make_output_csv_path_from_input(const char *input_path)
     ptr--;
   }
   
-  len = strlen(ptr);
+  len = strlen(ptr) + 1;
   output_file_path = (char *) malloc(len + 3);
 
   strncpy(output_file_path, ptr, len);
@@ -81,9 +81,11 @@ char * make_output_csv_path_from_input(const char *input_path)
   output_file_path[0] = '.';
   len++;
 
-  output_file_path[len - 3] = 'c';
-  output_file_path[len - 2] = 's';
-  output_file_path[len - 1] = 'v';
+  output_file_path[len - 4] = 'c';
+  output_file_path[len - 3] = 's';
+  output_file_path[len - 2] = 'v';
+  
+  output_file_path[len - 1] = '\0';
 
   return output_file_path;
 }


### PR DESCRIPTION
The variable output_file_path in decode_binary.c is not properly null-terminated, leading to potentially invalid file name characters and other issues. The attached patch increases the allocated string size and ensures the string is always null terminated.

Steps to reproduce

```
$ uname -a    
Darwin MacBook.local 14.0.0 Darwin Kernel Version 14.0.0: Fri Sep 19 00:26:44 PDT 2014; root:xnu-2782.1.97~2/RELEASE_X86_64 x86_64
$ clang --version
Apple LLVM version 6.0 (clang-600.0.56) (based on LLVM 3.5svn)
Target: x86_64-apple-darwin14.0.0
Thread model: posix
$ cat Makefile 
all:
    clang -Weverything -o decode_binary decode_binary.c

test:
    for i in {1..10}; do ./decode_binary foo.bin | grep -E 'csv[^\.]\.\.\.' - ; done ; true

$ make && make test
clang -Weverything -o decode_binary decode_binary.c
--Snip--
for i in {1..10}; do ./decode_binary foo.bin | grep -E 'csv[^\.]\.\.\.' - ; done ; true
Decoding file foo.bin and saving data to ./foo.csvp...
Decoding file foo.bin and saving data to ./foo.csvp...
Decoding file foo.bin and saving data to ./foo.csv0...
Decoding file foo.bin and saving data to ./foo.csv...
Decoding file foo.bin and saving data to ./foo.csv@...
```
