### PR TITLE
Fixed bug in tmp102_getTempCelsius() with temperatures below 0 degrees C

### DIFF
--- a/utility/drivers.cpp
+++ b/utility/drivers.cpp
@@ -767,7 +767,7 @@ boolean tmp102_init() {
 }
 
 float tmp102_getTempCelsius() {
-  uint16_t val;
+  int16_t val;
   uint8_t * bytes = (uint8_t *) &val;
   uint8_t temp_byte;
   float tmp;


### PR DESCRIPTION
- If the temperature was below 0 degrees C, tmp102_getTempCelsius() would
  return large positive values instead of the expected negative values
