### PR TITLE
TSL2561 saturation fix

### DIFF
--- a/utility/drivers.cpp
+++ b/utility/drivers.cpp
@@ -788,11 +788,38 @@ float tmp102_getTempCelsius() {
 TSL2561 tsl2561 = TSL2561(DRIVER_TSL2561_ADDR);
 
 boolean tsl2561_init() {
-  return tsl2561.begin();
+  boolean status = tsl2561.begin();
+
+  if(status)
+  {
+    // set gain to 1, as TSL2561 library defaults to 16,
+    // which will cause saturation of the signal-conditioned
+    // photodiodes when exposed to a strong light source,
+    // such as the outdoors
+    tsl2561.setGain(TSL2561_GAIN_0X);
+    // set integration time to 13 ms (currently, the TSL2561 library
+    // defaults to 13 ms integration time, but we should explicitly set
+    // to ensure this)
+    tsl2561.setTiming(TSL2561_INTEGRATIONTIME_13MS);
+  }
+
+  return status;
 }
 
 float tsl2561_getLux() {
+  // TODO: check for saturation of from either channel, and if so,
+  // or indicate to the user the sensor is saturation via a status
+  // code OR by setting the return value to a really high value (100,000?)
+  // TODO: if it is desired to improve resolution under low light values,
+  // we will need to dynamically change the gain and/or integration time
+  // settings
+
+  // read from channel 0 (IR + visible photodiode)
   uint16_t ch0 = tsl2561.getLuminosity(0);
+  // read from channel 1 (IR photodiode)
   uint16_t ch1 = tsl2561.getLuminosity(1);
+  // compute luminosity based on channel 0, channel 1 readings
+  // (NOTE: TSL2561::calculateLux() takes into account the gain and
+  // integration time)
   return tsl2561.calculateLux(ch0, ch1);
 }

--- a/utility/drivers.cpp
+++ b/utility/drivers.cpp
@@ -767,7 +767,7 @@ boolean tmp102_init() {
 }
 
 float tmp102_getTempCelsius() {
-  uint16_t val;
+  int16_t val;
   uint8_t * bytes = (uint8_t *) &val;
   uint8_t temp_byte;
   float tmp;


### PR DESCRIPTION
Ben

We (the WCS-MS2TC-1 team and I) ran into another bug this Tuesday while performing a preliminary test of the initial high-altitude balloon sketch I submitted on their behalf (by the way, did you receive it successfully?).  When we programmed the sketch on their SpaceKit and took it outside, we noticed the luminosity readings were lower than they were when we were still indoors; it would consistently read 53.0 outside until you placed an object in front of the sensor, at which time the readings jumped up.  Not sure what was happening, I told them I would look into the problem and have a fix by our meeting next Tuesday.  I also challenged them to try and figure out what was wrong and fix it (not very likely, but you never know...).

I read through the code as well as the TSL2561 datasheet, which led me to suspect the sensor was saturating, and thus causing the bad readings.  To test this, I put together a sketch which replicates the tsl2561_init() and tsl2561_getLux() functions from utility/drivers.cpp so that I could look at the individual photodiode readings as well as the computed lux value.  Sure enough, when exposed to a strong light source (the sun, or the torch LED from a smartphone held close to the sensor), the signal conditioned output of both photodiodes become saturated, causing garbage lux values.  When looking at the TSL2561 library, I noticed the gain was set to 16 by default.  Figuring this would not work well under strong light sources, I used the TSL2561::setGain() function to explicitly set it to 1, and now everything looked reasonable.

Given either the high-altitude balloon or the satellite will be outside and therefore potentially be exposed to the sun, setting the gain to 1 is an appropriate first step to correcting this problem.  I could, however, foresee experiments performed on the satellite where it will be desired to measure weak sources of light.  To handle this will require tsl2561_getLux() to automatically set the gain and/or integration time to maximize resolution without causing the photodiodes to saturate.  Moreover, it is possible, even with the gain turned all the way down, for the sensors to saturate; if so, tsl2561_getLux() will need to handle this as well by indicating this to the user somehow (either via status code or a pre-canned "high" lux value).

While this changeset fixes the immediate problem, I am not sure it is a complete solution.  I think more work needs to be done to insure this sensor interface works under all potential conditions.  Let me know what you think.

Michael Kirkhart
