### PR TITLE
Switch to TCS34725 from TSL2561

### DIFF
--- a/ArdusatSDK.cpp
+++ b/ArdusatSDK.cpp
@@ -634,107 +634,122 @@ const char * Gyro::toJSON(const char * sensorName) {
  * @endcode
  *****************************************************************************/
 Luminosity::Luminosity(void) :
-  gain(TSL2561_GAIN_1X),
-  intTime(TSL2561_INTEGRATIONTIME_13MS)
+  gain(TCS34725_GAIN_16X),
+  intTime(TCS34725_INTEGRATIONTIME_24MS)
 {
-  this->initializeHeader(SENSORID_TSL2561, DATA_UNIT_LUX, luminosity_sensor_name);
+  this->initializeHeader(SENSORID_TCS34725, DATA_UNIT_LUX, luminosity_sensor_name);
 }
 
 /**
  * @brief   Sets the integration time and gain configuration variables and constructs an object
  * @ingroup luminosity
  *
- * @param intTime Advanced configuration for TSL2561 integration time
- *     - TSL2561_INTEGRATIONTIME_13MS (Default)
- *     - TSL2561_INTEGRATIONTIME_101MS
- *     - TSL2561_INTEGRATIONTIME_402MS
- * @param gain Advanced configuration for TSL2561 gain
- *     - TSL2561_GAIN_1X (Default)
- *     - TSL2561_GAIN_16X
+ * @param intTime Advanced configuration for TCS34725 integration time
+ *     - TCS34725_INTEGRATIONTIME_2_4MS
+ *     - TCS34725_INTEGRATIONTIME_24MS (Default)
+ *     - TCS34725_INTEGRATIONTIME_50MS
+ *     - TCS34725_INTEGRATIONTIME_101MS
+ *     - TCS34725_INTEGRATIONTIME_154MS
+ *     - TCS34725_INTEGRATIONTIME_700MS
+ * @param gain Advanced configuration for TCS34725 gain
+ *     - TCS34725_GAIN_1X
+ *     - TCS34725_GAIN_4X
+ *     - TCS34725_GAIN_16X (Default)
+ *     - TCS34725_GAIN_60X
  *
  * Example Usage:
  * @code
- *     Luminosity lum(TSL2561_INTEGRATIONTIME_101MS, TSL2561_GAIN_16X);
+ *     Luminosity lum(TCS34725_INTEGRATIONTIME_101MS, TCS34725_GAIN_16X);
  *     lum.begin();                           // Initialize sensor
  *     Serial.println(lum.readToJSON("lum")); // Read and print values in JSON
  * @endcode
  */
-Luminosity::Luminosity(tsl2561IntegrationTime_t intTime, tsl2561Gain_t gain) :
+Luminosity::Luminosity(tcs34725IntegrationTime_t intTime, tcs34725Gain_t gain) :
   gain(gain),
   intTime(intTime)
 {
-  this->initializeHeader(SENSORID_TSL2561, DATA_UNIT_LUX, luminosity_sensor_name);
+  this->initializeHeader(SENSORID_TCS34725, DATA_UNIT_LUX, luminosity_sensor_name);
 }
 
 /**
  * @brief   Sets the gain and integration time configuration variables and constructs an object
  * @ingroup luminosity
  *
- * @param gain Advanced configuration for TSL2561 gain
- *     - TSL2561_GAIN_1X (Default)
- *     - TSL2561_GAIN_16X
- * @param intTime Advanced configuration for TSL2561 integration time
- *     - TSL2561_INTEGRATIONTIME_13MS (Default)
- *     - TSL2561_INTEGRATIONTIME_101MS
- *     - TSL2561_INTEGRATIONTIME_402MS
+ * @param gain Advanced configuration for TCS34725 gain
+ *     - TCS34725_GAIN_1X
+ *     - TCS34725_GAIN_4X
+ *     - TCS34725_GAIN_16X (Default)
+ *     - TCS34725_GAIN_60X
+ * @param intTime Advanced configuration for TCS34725 integration time
+ *     - TCS34725_INTEGRATIONTIME_2_4MS
+ *     - TCS34725_INTEGRATIONTIME_24MS (Default)
+ *     - TCS34725_INTEGRATIONTIME_50MS
+ *     - TCS34725_INTEGRATIONTIME_101MS
+ *     - TCS34725_INTEGRATIONTIME_154MS
+ *     - TCS34725_INTEGRATIONTIME_700MS
  *
  * Example Usage:
  * @code
- *     Luminosity lum(TSL2561_GAIN_16X, TSL2561_INTEGRATIONTIME_101MS);
+ *     Luminosity lum(TCS34725_GAIN_16X, TCS34725_INTEGRATIONTIME_101MS);
  *     lum.begin();                           // Initialize sensor
  *     Serial.println(lum.readToJSON("lum")); // Read and print values in JSON
  * @endcode
  */
-Luminosity::Luminosity(tsl2561Gain_t gain, tsl2561IntegrationTime_t intTime) :
+Luminosity::Luminosity(tcs34725Gain_t gain, tcs34725IntegrationTime_t intTime) :
   gain(gain),
   intTime(intTime)
 {
-  this->initializeHeader(SENSORID_TSL2561, DATA_UNIT_LUX, luminosity_sensor_name);
+  this->initializeHeader(SENSORID_TCS34725, DATA_UNIT_LUX, luminosity_sensor_name);
 }
 
 /**
  * @brief   Sets the integration time configuration variable and constructs an object
  * @ingroup luminosity
  *
- * @param intTime Advanced configuration for TSL2561 integration time
- *     - TSL2561_INTEGRATIONTIME_13MS (Default)
- *     - TSL2561_INTEGRATIONTIME_101MS
- *     - TSL2561_INTEGRATIONTIME_402MS
+ * @param intTime Advanced configuration for TCS34725 integration time
+ *     - TCS34725_INTEGRATIONTIME_2_4MS
+ *     - TCS34725_INTEGRATIONTIME_24MS (Default)
+ *     - TCS34725_INTEGRATIONTIME_50MS
+ *     - TCS34725_INTEGRATIONTIME_101MS
+ *     - TCS34725_INTEGRATIONTIME_154MS
+ *     - TCS34725_INTEGRATIONTIME_700MS
  *
  * Example Usage:
  * @code
- *     Luminosity lum(TSL2561_INTEGRATIONTIME_101MS); // Instantiate sensor object
- *     lum.begin();                                   // Initialize sensor
- *     Serial.println(lum.readToJSON("lum"));         // Read and print values in JSON
+ *     Luminosity lum(TCS34725_INTEGRATIONTIME_101MS); // Instantiate sensor object
+ *     lum.begin();                                    // Initialize sensor
+ *     Serial.println(lum.readToJSON("lum"));          // Read and print values in JSON
  * @endcode
  */
-Luminosity::Luminosity(tsl2561IntegrationTime_t intTime) :
-  gain(TSL2561_GAIN_1X),
+Luminosity::Luminosity(tcs34725IntegrationTime_t intTime) :
+  gain(TCS34725_GAIN_16X),
   intTime(intTime)
 {
-  this->initializeHeader(SENSORID_TSL2561, DATA_UNIT_LUX, luminosity_sensor_name);
+  this->initializeHeader(SENSORID_TCS34725, DATA_UNIT_LUX, luminosity_sensor_name);
 }
 
 /**
  * @brief   Sets the gain configuration variable and constructs an object
  * @ingroup luminosity
  *
- * @param gain Advanced configuration for TSL2561 gain
- *     - TSL2561_GAIN_1X (Default)
- *     - TSL2561_GAIN_16X
+ * @param gain Advanced configuration for TCS34725 gain
+ *     - TCS34725_GAIN_1X
+ *     - TCS34725_GAIN_4X
+ *     - TCS34725_GAIN_16X (Default)
+ *     - TCS34725_GAIN_60X
  *
  * Example Usage:
  * @code
- *     Luminosity lum(TSL2561_GAIN_16X);      // Instantiate sensor object
+ *     Luminosity lum(TCS34725_GAIN_16X);     // Instantiate sensor object
  *     lum.begin();                           // Initialize sensor
  *     Serial.println(lum.readToJSON("lum")); // Read and print values in JSON
  * @endcode
  */
-Luminosity::Luminosity(tsl2561Gain_t gain) :
+Luminosity::Luminosity(tcs34725Gain_t gain) :
   gain(gain),
-  intTime(TSL2561_INTEGRATIONTIME_13MS)
+  intTime(TCS34725_INTEGRATIONTIME_24MS)
 {
-  this->initializeHeader(SENSORID_TSL2561, DATA_UNIT_LUX, luminosity_sensor_name);
+  this->initializeHeader(SENSORID_TCS34725, DATA_UNIT_LUX, luminosity_sensor_name);
 }
 
 /**
@@ -745,7 +760,7 @@ Luminosity::Luminosity(tsl2561Gain_t gain) :
  * @retval false Failed to initialize
  */
 boolean Luminosity::initialize(void) {
-  return tsl2561_init(this->intTime, this->gain);
+  return tcs34725_init(this->intTime, this->gain);
 }
 
 /**
@@ -756,7 +771,7 @@ boolean Luminosity::initialize(void) {
  * @retval false Failed to read
  */
 boolean Luminosity::readSensor(void) {
-  this->lux = tsl2561_getLux();
+  this->lux = tcs34725_getLux();
   return true;
 }
 

--- a/ArdusatSDK.h
+++ b/ArdusatSDK.h
@@ -238,7 +238,7 @@ class Gyro: public Sensor {
  * @brief Encapsulates all functionality related to the Luminosity Sensor
  *
  * This class can be used to initialize, further configure, read, and print
- * data receieved from the TSL2561 board
+ * data receieved from the TCS34725 board
  *
  * Example Usage:
  * @code
@@ -249,8 +249,8 @@ class Gyro: public Sensor {
  *****************************************************************************/
 class Luminosity: public Sensor {
   protected:
-    tsl2561Gain_t gain;
-    tsl2561IntegrationTime_t intTime;
+    tcs34725Gain_t gain;
+    tcs34725IntegrationTime_t intTime;
 
     boolean initialize(void);
     boolean readSensor(void);
@@ -258,10 +258,10 @@ class Luminosity: public Sensor {
   public:
     float lux;
     Luminosity(void);
-    Luminosity(tsl2561IntegrationTime_t intTime, tsl2561Gain_t gain);
-    Luminosity(tsl2561Gain_t gain, tsl2561IntegrationTime_t intTime);
-    Luminosity(tsl2561IntegrationTime_t intTime);
-    Luminosity(tsl2561Gain_t gain);
+    Luminosity(tcs34725IntegrationTime_t intTime, tcs34725Gain_t gain);
+    Luminosity(tcs34725Gain_t gain, tcs34725IntegrationTime_t intTime);
+    Luminosity(tcs34725IntegrationTime_t intTime);
+    Luminosity(tcs34725Gain_t gain);
 
     const char * toCSV(const char * sensorName);
     const char * toJSON(const char * sensorName);

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Sensor Class | Sensors | Required Constructor Arguments
 --- | --- | ---
 Acceleration   | LSM303 (9DOF breakout)   | `None`
 Gyro           | L3GD20 (9DOF breakout)   | `None`
-Luminosity     | TSL2561                  | `None`
+Luminosity     | TCS34725                 | `None`
 Magnetic       | LSM303 (9DOF breakout)   | `None`
 Orientation    | Derived from Acceleration and Magnetic | `Acceleration & accel, Magnetic & mag` (Existing Accel and Mag objects)
 Pressure       | BMP180                   | `None`
@@ -127,7 +127,7 @@ Sensor Class | Data Fields | Optional Constructor Parameters (for advanced confi
 --- | --- | ---
 Acceleration   | `float x`, `float y`, `float z`              | `lsm303_accel_gain_e gGain`
 Gyro           | `float x`, `float y`, `float z`              | `uint8_t range`
-Luminosity     | `float lux`                                  | `tsl2561IntegrationTime_t intTime`, `tsl2561Gain_t gain`
+Luminosity     | `float lux`                                  | `tcs34725IntegrationTime_t intTime`, `tcs34725Gain_t gain`
 Magnetic       | `float x`, `float y`, `float z`              | `lsm303_mag_scale_e gaussScale`
 Orientation    | `float roll`, `float pitch`, `float heading` | `None`
 Pressure       | `float pressure`                             | `bmp085_mode_t mode`
@@ -148,8 +148,8 @@ Constructor Configuration Parameter Type | Acceptable Values | Sensor Class
 --- | --- | ---
 `lsm303_accel_gain_e gGain` | `LSM303_ACCEL_GAIN2G`, `LSM303_ACCEL_GAIN4G`, `LSM303_ACCEL_GAIN6G`, `LSM303_ACCEL_GAIN8G` (Default), `LSM303_ACCEL_GAIN16G` | Acceleration
 `uint8_t range` | `0x00` (SENSITIVITY_250DPS), `0x10` (SENSITIVITY_500DPS), `0x20` (SENSITIVITY_2000DPS) (Default) | Gyro
-`tsl2561IntegrationTime_t intTime` | `TSL2561_INTEGRATIONTIME_13MS` (Default), `TSL2561_INTEGRATIONTIME_101MS`, `TSL2561_INTEGRATIONTIME_402MS` | Luminosity
-`tsl2561Gain_t gain` | `TSL2561_GAIN_1X` (Default), `TSL2561_GAIN_16X` | Luminosity
+`tcs34725IntegrationTime_t intTime` | `TCS34725_INTEGRATIONTIME_2_4MS`, `TCS34725_INTEGRATIONTIME_24MS` (Default), `TCS34725_INTEGRATIONTIME_50MS`, `TCS34725_INTEGRATIONTIME_101MS`, `TCS34725_INTEGRATIONTIME_154MS`, `TCS34725_INTEGRATIONTIME_700MS` | Luminosity
+`tcs34725Gain_t gain` | `TCS34725_GAIN_1X`, `TCS34725_GAIN_4X`, `TCS34725_GAIN_16X` (Default), `TCS34725_GAIN_60X` | Luminosity
 `lsm303_mag_scale_e gaussScale` | `LSM303_MAG_SCALE1_3GAUSS`, `LSM303_MAG_SCALE2GAUSS`, `LSM303_MAG_SCALE2_5GAUSS`, `LSM303_MAG_SCALE4GAUSS` (Default), `LSM303_MAG_SCALE4_7GAUSS`, `LSM303_MAG_SCALE5_6GAUSS`, `LSM303_MAG_SCALE8GAUSS`, `LSM303_MAG_SCALE12GAUSS` | Magnetic
 `bmp085_mode_t mode` | `BMP085_MODE_ULTRALOWPOWER`, `BMP085_MODE_STANDARD`, `BMP085_MODE_HIGHRES`, `BMP085_MODE_ULTRAHIGHRES` (Default) | Pressure
 `tcs34725IntegrationTime_t it` | `TCS34725_INTEGRATIONTIME_2_4MS`, `TCS34725_INTEGRATIONTIME_24MS`, `TCS34725_INTEGRATIONTIME_50MS`, `TCS34725_INTEGRATIONTIME_101MS`, `TCS34725_INTEGRATIONTIME_154MS` (Default), `TCS34725_INTEGRATIONTIME_700MS` | RGBLightTCS

--- a/examples/all-sensor-display/all-sensor-display.ino
+++ b/examples/all-sensor-display/all-sensor-display.ino
@@ -8,7 +8,7 @@ Display display;
 
 Acceleration acc;
 Gyro         gyr;
-Luminosity   lum(TSL2561_INTEGRATIONTIME_13MS);
+Luminosity   lum;
 RGBLightTCS  rgb(TCS34725_INTEGRATIONTIME_24MS);
 Magnetic     mag;
 Temperature  tmp;

--- a/examples/all_sensors/all_sensors.ino
+++ b/examples/all_sensors/all_sensors.ino
@@ -109,7 +109,7 @@ void loop(void)
   // Read MLX Infrared temp sensor
   serialConnection.println(infrared.readToJSON("infraredTemp"));
 
-  // Read TSL2561 Luminosity
+  // Read TCS34725 Luminosity
   serialConnection.println(lum.readToJSON("luminosity"));
 
   // Read Magnetometer

--- a/examples/luminosity/luminosity.ino
+++ b/examples/luminosity/luminosity.ino
@@ -47,13 +47,13 @@ ArdusatSerial serialConnection(SERIAL_MODE_HARDWARE_AND_SOFTWARE, 8, 9);
                                    "//" at the beginning of the next line and
                                    remove the "//" at the beginning of the
                                    configuration you want to use */
-Luminosity lum; // => TSL2561_INTEGRATIONTIME_13MS, TSL2561_GAIN_1X
+Luminosity lum; // => TCS34725_INTEGRATIONTIME_24MS, TCS34725_GAIN_16X
 
 /* Useful outside or in very bright room */
-//Luminosity lum(TSL2561_INTEGRATIONTIME_13MS, TSL2561_GAIN_1X);
+//Luminosity lum(TCS34725_INTEGRATIONTIME_24MS, TCS34725_GAIN_1X);
 
 /* Useful at night or in dark room */
-//Luminosity lum(TSL2561_INTEGRATIONTIME_402MS, TSL2561_GAIN_16X);
+//Luminosity lum(TCS34725_INTEGRATIONTIME_154MS, TSL2561_GAIN_60X);
 
 
 /*

--- a/utility/drivers.cpp
+++ b/utility/drivers.cpp
@@ -993,6 +993,12 @@ void tcs34725_getRGB(float *red, float *green, float *blue) {
   *blue = b;
 }
 
+float tcs34725_getLux() {
+  uint16_t r, g, b, clear;
+  
+  tcs34725.getRawData(&r, &g, &b, &clear);
+  return (float)tcs34725.calculateLux(r, g, b);
+}
 
 /*
  * SI1132 UV Light Sensor

--- a/utility/drivers.h
+++ b/utility/drivers.h
@@ -183,6 +183,7 @@ void isl29125_getRGB(float * red, float * green, float * blue);
  */
 boolean tcs34725_init(tcs34725IntegrationTime_t it, tcs34725Gain_t gain);
 void tcs34725_getRGB(float * red, float * green, float * blue);
+float tcs34725_getLux();
 
 /**
  * SI1132 UV/Light sensor uses the SI1145 driver provided by Adafruit.


### PR DESCRIPTION
TSL2561 is no longer available as a sensor, so the luminosity reading from TCS34725 will work as an alternative.